### PR TITLE
Allow foreign key constraints in create table statements

### DIFF
--- a/src/main/java/com/premiumminds/sonar/postgres/visitors/AddForeignKeyVisitorCheck.java
+++ b/src/main/java/com/premiumminds/sonar/postgres/visitors/AddForeignKeyVisitorCheck.java
@@ -24,20 +24,6 @@ public class AddForeignKeyVisitorCheck extends AbstractVisitorCheck {
         super.visitAlterTableColumnConstraint(constraint);
     }
 
-    @Override
-    public void visitCreateTableColumnConstraint(Constraint constraint) {
-        visitConstraint(constraint);
-
-        super.visitCreateTableColumnConstraint(constraint);
-    }
-
-    @Override
-    public void visitCreateTableTableConstraint(Constraint constraint) {
-        visitConstraint(constraint);
-
-        super.visitCreateTableTableConstraint(constraint);
-    }
-
     private void visitConstraint(Constraint constraint) {
         final ConstrType contype = constraint.getContype();
         if (ConstrType.CONSTR_FOREIGN.equals(contype) && constraint.getInitiallyValid() && !constraint.getSkipValidation()){


### PR DESCRIPTION
Defining foreign keys in create table statements is blocking but fast due to not having to check exiting rows.

partial fix for #5 