### PR TITLE
Hard code file.encoding for unit tests for all OS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,14 @@
                     <release>${java.version}</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Tests fail in Windows due to default file.encoding not being UTF-8

protobuf requires UTF8. JNA uses the default file.encoding or the newer native.encoding with a custom jna.encoding

Attempts to provide the proper charsets to jna failed. 
https://stackoverflow.com/questions/62875199/jna-change-string-encoding-for-only-one-external-native-library https://protobuf.dev/programming-guides/proto3/#scalar