### PR TITLE
Configuring plugins for analyzer loading optimization

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -42,9 +42,12 @@ mvn clean package
    - password: admin
 
 ```shell
-docker run -d --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 sonarqube:lts-community
-docker cp target/sonar-postgres-plugin-1.0-SNAPSHOT.jar sonarqube:/opt/sonarqube/extensions/plugins/
-docker restart sonarqube
+docker run -d \
+    --name sonarqube \
+    -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true \
+    -p 9000:9000 \
+    -v $(pwd)/target/sonar-postgres-plugin-1.2-SNAPSHOT.jar:/opt/sonarqube/extensions/plugins/sonar-postgres-plugin-1.2-SNAPSHOT.jar \
+    sonarqube:lts-community
 xdg-open http://localhost:9000/
 docker logs -f sonarqube
 ```
@@ -61,9 +64,9 @@ mvn sonar:sonar \
 ### SonarScanner
 
 ```shell
-wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip
-unzip sonar-scanner-cli-4.7.0.2747-linux.zip
-cd sonar-scanner-4.7.0.2747-linux
+wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
+unzip sonar-scanner-cli-5.0.1.3006-linux.zip
+cd sonar-scanner-5.0.1.3006-linux
 bin/sonar-scanner \
   -Dsonar.login=admin \
   -Dsonar.password=admin1 \

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
                 <configuration>
                     <pluginKey>communitypostgres</pluginKey>
                     <pluginClass>com.premiumminds.sonar.postgres.PostgresSQLExtension</pluginClass>
+                    <requiredForLanguages>postgres-language</requiredForLanguages>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/premiumminds/sonar/postgres/PostgresSqlLanguage.java
+++ b/src/main/java/com/premiumminds/sonar/postgres/PostgresSqlLanguage.java
@@ -5,12 +5,12 @@ import org.sonar.api.resources.AbstractLanguage;
 
 public class PostgresSqlLanguage extends AbstractLanguage {
 
-    public static final String FILE_SUFFIXES_KEY = "sonar.postgres.file.suffixes";
-    public static final String FILE_EXCLUSIONS_KEY = "sonar.postgres.exclusions";
-    public static final String FILE_SUFFIXES_DEFAULT_VALUE = ".sql";
-
     public static final String NAME = "PostgreSQL";
     public static final String KEY = "postgres-language";
+    public static final String FILE_SUFFIXES_KEY = "sonar." + KEY + ".file.suffixes";
+    public static final String FILE_EXCLUSIONS_KEY = "sonar." + KEY + ".exclusions";
+    public static final String FILE_SUFFIXES_DEFAULT_VALUE = "sql";
+
 
     private final Configuration config;
 


### PR DESCRIPTION
Changed configuration key to match language key.
Without this, it breaks on 10.4 and up.

fixes #42 